### PR TITLE
Build without CEPH

### DIFF
--- a/lib/TimeStore.hs
+++ b/lib/TimeStore.hs
@@ -12,6 +12,8 @@
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
+{-# OPTIONS -cpp #-}
+
 module TimeStore
 (
     -- * Types
@@ -34,11 +36,13 @@ module TimeStore
     isRegistered,
     fetchIndex,
 
+#if defined RADOS
     -- * Rados store (ceph)
     RadosStore(..),
     radosStore,
     cleanupRadosStore,
     withRadosStore,
+#endif
 
     -- * Memory store (testing)
     MemoryStore,
@@ -63,7 +67,9 @@ import TimeStore.Core
 import TimeStore.Index
 import TimeStore.StoreHelpers
 import TimeStore.Stores.Memory
+#if defined RADOS
 import TimeStore.Stores.Rados
+#endif
 
 -- | Check if a namespace is registered.
 isRegistered :: Store s => s -> NameSpace -> IO Bool

--- a/rados-timestore.cabal
+++ b/rados-timestore.cabal
@@ -16,6 +16,10 @@ source-repository    head
   type:              git
   location:          git@github.com:anchor/rados-timestore.git
 
+flag rados
+  description: Whether to build with rados backend support.
+  default: True
+
 library
   hs-source-dirs:    lib
   default-language:  Haskell2010
@@ -26,9 +30,8 @@ library
                      TimeStore.Index,
                      TimeStore.Core,
                      TimeStore.StoreHelpers,
-                     TimeStore.Stores.Memory,
-                     TimeStore.Stores.Rados
-                     
+                     TimeStore.Stores.Memory
+
   build-depends:     base >=3 && <5,
                      bytestring,
                      packer,
@@ -44,8 +47,7 @@ library
                      pretty-hex,
                      spool,
                      tagged,
-                     containers,
-                     rados-haskell >= 3.1.0
+                     containers
 
   ghc-options:       -O2
                      -threaded
@@ -54,6 +56,12 @@ library
                      -fwarn-tabs
 
   ghc-prof-options:  -auto-all
+
+  if flag(rados)
+    CC-Options: "-DRADOS"
+    build-depends:   rados-haskell >= 3.1.0
+    other-modules:   TimeStore.Stores.Rados
+
 
 executable store
   hs-source-dirs:    src
@@ -72,7 +80,6 @@ executable store
                      -Wwarn
                      -fwarn-tabs
 
---   ghc-prof-options:  -fprof-auto
 
 test-suite           unit-tests
   hs-source-dirs:    tests, lib
@@ -97,10 +104,13 @@ test-suite           unit-tests
                      tagged,
                      containers,
                      spool,
-                     rados-timestore,
-                     rados-haskell >= 3.1.0
+                     rados-timestore
   ghc-options:       -threaded
   ghc-prof-options:  -auto-all
+
+  if flag(rados)
+    CC-Options: "-DRADOS"
+    build-depends:   rados-haskell >= 3.1.0
 
 
 test-suite           fuzzy-tests
@@ -127,10 +137,14 @@ test-suite           fuzzy-tests
                      tagged,
                      containers,
                      spool,
-                     rados-timestore,
-                     rados-haskell >= 3.1.0
+                     rados-timestore
   ghc-options:       -threaded
   ghc-prof-options:  -auto-all
+
+  if flag(rados)
+    CC-Options: "-DRADOS"
+    build-depends:   rados-haskell >= 3.1.0
+
 
 test-suite           store-tests
   hs-source-dirs:    tests, lib
@@ -156,10 +170,10 @@ test-suite           store-tests
                      tagged,
                      containers,
                      spool,
-                     rados-timestore,
-                     rados-haskell >= 3.1.0
+                     rados-timestore
   ghc-options:       -threaded
   ghc-prof-options:  -auto-all
 
-
--- vim: set tabstop=21 expandtab:
+  if flag(rados)
+    CC-Options: "-DRADOS"
+    build-depends:   rados-haskell >= 3.1.0

--- a/src/Store.hs
+++ b/src/Store.hs
@@ -7,9 +7,16 @@
 -- the 3-clause BSD licence.
 --
 
+{-# OPTIONS -cpp #-}
+
 module Main where
-import qualified Data.ByteString.Char8 as S
+
 import Options.Applicative
+
+#if defined RADOS
+import qualified Data.ByteString.Char8 as S
+#endif
+
 import TimeStore
 
 data Options
@@ -79,6 +86,7 @@ registerActionParser = Register <$> parseSimpleBuckets
 
 main :: IO ()
 main = do
+#if defined RADOS
     Options pool user ns cmd <- execParser helpfulParser
 
     case cmd of
@@ -91,3 +99,6 @@ main = do
             if registered
                 then putStrLn "Origin already registered"
                 else registerNamespace s ns s_buckets e_buckets
+#else
+    putStrLn "No CEPH"
+#endif

--- a/tests/FuzzyTests.hs
+++ b/tests/FuzzyTests.hs
@@ -228,7 +228,7 @@ propImmutableStore (ImmutableWrites addrs writes p)
                    (Positive rollover) = monadicIO $ do
     res <- run $ do
         s <- memoryStore rollover
-        registerNamespace s testNS s_buckets e_buckets
+        registerNamespace s testNS (Bucket s_buckets) (Bucket e_buckets)
         mapM_ (writeEncoded s testNS) writes
         foldM (lookupAndInsert s) mempty addrs
     assert . either error (const True) $ unProposition p res
@@ -251,4 +251,3 @@ propGroupsPoints ix1 ix2 (MixedPayload x) =
     -- extended max. This is because adding an extended point will add a
     -- pointer to the simple bucket.
     in e_max <= s_max
-

--- a/tests/StoreTests.hs
+++ b/tests/StoreTests.hs
@@ -13,26 +13,25 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# OPTIONS -cpp #-}
 
-import           Control.Applicative
-import           Control.Concurrent (threadDelay)
-import           Control.Concurrent.Async
-import           Control.Monad
-import           Data.ByteString (ByteString)
+import Control.Applicative
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async
+import Control.Monad
+import Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as S
-import           Data.Function
-import           Data.List
-import           Data.Monoid
+import Data.Function
+import Data.List
+import Data.Monoid
 #if defined RADOS
 import qualified System.Rados.Monadic as R
 #endif
-import           Test.Hspec
-import           Test.Hspec.Core (SpecM)
-import           Test.Hspec.QuickCheck
-import           Test.QuickCheck hiding (reason, theException)
-import           Test.QuickCheck.Monadic
-
-import           TimeStore
-import           TimeStore.Core
+import Test.Hspec
+import Test.Hspec.Core (SpecM)
+import Test.Hspec.QuickCheck
+import Test.QuickCheck hiding (reason, theException)
+import Test.QuickCheck.Monadic
+import TimeStore
+import TimeStore.Core
 
 newtype ValidBS
     = ValidBS { unValidBS :: ByteString }


### PR DESCRIPTION
Added a `RADOS` cpp flag to build without librados. Tested on OS X without CEPH, would probably be a good idea to test with CEPH before merge. 
